### PR TITLE
[FIX] quantity attribute name on sync line from ERP

### DIFF
--- a/src/cartLineData.ts
+++ b/src/cartLineData.ts
@@ -27,7 +27,7 @@ export class CartLineData {
     return new this(
       false,
       erpCartLine.product_id,
-      erpCartLine.quantity,
+      erpCartLine.qty,
       erpCartLine
     );
   }


### PR DESCRIPTION
API Sync endpoint return "qty" attribute instead of quantity.