### PR TITLE
Never create transactions with null quantity

### DIFF
--- a/src/cartTransaction.ts
+++ b/src/cartTransaction.ts
@@ -11,7 +11,7 @@ export class CartTransaction {
 
   constructor(productId: number, qty: number, uuid?: string) {
     this.productId = productId;
-    this.qty = qty;
+    this.qty = qty || 0;
     this.uuid = uuid || uuidv4();
   }
 


### PR DESCRIPTION
This situation is probably a bug by the client, but let's
avoid storing invalid data in the store.