### PR TITLE
[FIX] Support empty response from sync API on fromErpCart method

### DIFF
--- a/src/cartData.ts
+++ b/src/cartData.ts
@@ -14,11 +14,11 @@ export class CartData {
 
   public erpCart: any;
 
-  static fromErpCart(erpCart: any): CartData {
+  static fromErpCart(erpCart: any | null): CartData {
     const cartData = new this();
     cartData.erpCart = erpCart;
     cartData.lines = [];
-    if (erpCart) {
+    if (erpCart && Array.isArray(erpCart?.lines)) {
       for (const erpCartLine of erpCart.lines) {
         cartData.addLine(CartLineData.fromErpCartLine(erpCartLine));
       }


### PR DESCRIPTION
Support empty response from sync API. An empty response occurred when the current customer haven't a pending cart the ERP.