### PR TITLE
Fix empty response on sync

### DIFF
--- a/src/cart.ts
+++ b/src/cart.ts
@@ -135,10 +135,16 @@ export class Cart {
         'response'
       );
       if (response.ok) {
-        this.erpCart = await response.json();
-        if (Object.keys(this.erpCart).length === 0) {
-          // an empty object means no cart
+        // If a cart exists, it is returned with the response.
+        // otherwise, the response is null.
+        if (response.status === 204 ) {
           this.erpCart = null;
+        } else {
+          this.erpCart = await response.json();
+          if (Object.keys(this.erpCart).length === 0) {
+            // an empty object means no cart
+            this.erpCart = null;
+          }
         }
         success = true;
         this.syncError = false;


### PR DESCRIPTION
If cart exists the call the the 'sync' method will return a json. Otherwise an empty response id returned. Check the status code (204 means no content) and the content type to know if we can safely call 'response.json()'